### PR TITLE
Update to Java 11 toolchain to support M1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,6 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }


### PR DESCRIPTION
On an M1 mac, the toolchain will fail to download a toolchain meeting the requirements and the build will fail. Upgrading to Java 11 will yield a compatible toolchain and thus the build will succeed because adoptium has a JDK 11 for M1.
[See failure here](https://scans.gradle.com/s/lvs3compzseok/failure)

[See this issue](https://github.com/gradle/gradle/issues/19140) for more information.
