### PR TITLE
Fix CI warning by updating action dependencies

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -19,6 +19,6 @@ jobs:
         java-version: '8'
         distribution: 'temurin'
     - name: Set up Gradle Build Action
-      uses: gradle/gradle-build-action@v2.2.1
+      uses: gradle/gradle-build-action@v2.4.2
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -19,6 +19,6 @@ jobs:
         java-version: '8'
         distribution: 'temurin'
     - name: Set up Gradle Build Action
-      uses: gradle/gradle-build-action@v2.4.2
+      uses: gradle/gradle-build-action@v2
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate
         uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
This pr fixes warnings (`save-state` and node 12 deprecation) of both CI workflows by bumping `gradle/gradle-build-action` and `actions/checkout`.