### PR TITLE
Enable configuration cache by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true


### PR DESCRIPTION
Gradle 8.1 comes with stable configuration cache. Let's enable it by default, to enable, amongst other things, intra-project task execution parallelism.