### PR TITLE
Add Renovate configuration for wrapper upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "github>gradle/renovate-agent//presets/dv.json5"
+  ]
+}


### PR DESCRIPTION
## Summary
Gradle wrapper upgrades for this repo are currently managed centrally from `gradle/dv-solutions` using the `org.gradle.wrapper-upgrade` Gradle plugin. We are migrating away from this centralized approach so that each repo owns its own wrapper updates directly via Renovate.

This PR adds a `.github/renovate.json5` configuration that extends the standard Gradle org Renovate preset. Renovate's built-in `gradle-wrapper` manager will automatically detect and upgrade the Gradle wrapper.

## Prerequisites
- `gradle/renovate-agent` must be updated to include this repo (see gradle/renovate-agent#139)
- `bot-gh-dv-shared` needs write access to this repo