### PR TITLE
Fix broken Develocity docs link (docs.develocity.ai)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The Build Scan™ quickstart project is open-source software released under the 
 
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html
 [gradle-download]: https://gradle.org/install/
-[manual]: https://docs.gradle.com/develocity/gradle-plugin/current/
+[manual]: https://docs.develocity.ai/gradle/current/
 [gradle.com]: https://www.gradle.com
 [terms-of-service]: https://gradle.com/terms-of-service
 [scans.gradle.com]: https://scans.gradle.com/


### PR DESCRIPTION
## Summary

The `[manual]` link in the README pointed at `https://docs.gradle.com/develocity/gradle-plugin/current/`, which now returns **404** (it 301-redirects to `docs.develocity.ai/gradle-plugin/current/`, a path that no longer exists under the new docs domain).

This updates it to the current canonical Gradle plugin docs home:

```
https://docs.develocity.ai/gradle/current/   (200 OK)
```

Caught by the README link check in `gradle/dv-docs` ([run](https://github.com/gradle/dv-docs/actions/runs/28697995895)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)